### PR TITLE
Update containers.py

### DIFF
--- a/services/application/containers.py
+++ b/services/application/containers.py
@@ -1,5 +1,5 @@
 # Third-Party Libraries
-from lagom import Container
+from lagom import Container, Singleton
 
 # RG Libraries
 from services.adapters.user.i_user_adapter import IUserAdapter
@@ -12,6 +12,6 @@ from services.application.ports.outgoing.i_user_output_port import IUserOutputPo
 from services.application.ports.outgoing.user_output_port import UserOutputPort
 
 container = Container()
-container[IUserAdapter] = container[DynamoDBUserAdapter]
-container[IUserOutputPort] = container[UserOutputPort]
-container[IUserInputPort] = container[ApiGatewayUserInputPort]
+container[IUserAdapter] = Singleton(DynamoDBUserAdapter)
+container[IUserOutputPort] = Singleton(UserOutputPort)
+container[IUserInputPort] = Singleton(ApiGatewayUserInputPort)


### PR DESCRIPTION
In your code the concrete classes matching those interfaces gets constructed when this module is imported. If you switch to singleton definitions they will only be loaded when needed.

Obviously this may not be what you want if you're sure you always need all three to be initialised but it's worth considering. 